### PR TITLE
Fix assets location

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -8,7 +8,7 @@ location __PATH__/ {
   # Common parameter to increase upload size limit in conjunction with dedicated php-fpm file
   #client_max_body_size 50M;
 
-  location __PATH__/libreto/assets/ {
+  location __PATH__/assets/ {
      alias __FINALPATH__/libreto/assets/;
   }
   # IF YOU CHANGE SOMETHING IN THIS CONFIGURATION


### PR DESCRIPTION


## Problem
Assets location was requested at /libreto/assets, which is [root path]/assets. But Nginx configuration was to serve /assets/ as
/libreto/libreto/assets/  

## Solution
Remove /libreto/ because __PATH__ is already /libreto/

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)