### PR TITLE
Fix regressions 

### DIFF
--- a/conf/config.dist.php
+++ b/conf/config.dist.php
@@ -43,15 +43,15 @@ $providers = array(
     'html'                       => true,
   ),
 );
-// CUSTOM_PROVIDER$providers += array(
-// CUSTOM_PROVIDER  '__PROVIDER__'  => array(
-// CUSTOM_PROVIDER    'name'                       => "__PROVIDER__",
-// CUSTOM_PROVIDER    'url'                        => "__ETHERPAD_INSTANCE__",
-// CUSTOM_PROVIDER    'default_text'               => "Get involved with Etherpad at http://etherpad.org",
-// CUSTOM_PROVIDER    'markdown'                   => true,
-// CUSTOM_PROVIDER    'html'                       => true,
-// CUSTOM_PROVIDER  ),
-// CUSTOM_PROVIDER);
+__COMMENTED_PROVIDER__$providers += array(
+__COMMENTED_PROVIDER__  '__PROVIDER__'  => array(
+__COMMENTED_PROVIDER__    'name'                       => "__PROVIDER__",
+__COMMENTED_PROVIDER__    'url'                        => "__ETHERPAD_INSTANCE__",
+__COMMENTED_PROVIDER__    'default_text'               => "Get involved with Etherpad at http://etherpad.org",
+__COMMENTED_PROVIDER__    'markdown'                   => true,
+__COMMENTED_PROVIDER__    'html'                       => true,
+__COMMENTED_PROVIDER__  ),
+__COMMENTED_PROVIDER__);
 
 $options = array(
   'name'                            => "Libreto",

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -9,7 +9,7 @@ location __PATH__/ {
   # Common parameter to increase upload size limit in conjunction with dedicated php-fpm file
   client_max_body_size 50M;
 
-  location __PATH__/assets/ {
+  location __PATH__/libreto/assets/ {
      alias __INSTALL_DIR__/libreto/libreto/assets/;
   }
 


### PR DESCRIPTION
## Problem

Libreto install has been broken since recent changes
 - the assets (.js, .css, ...) are failing to load in the browser. It's not clear to me where this regression is exactly coming from. This is the same issue as @rodinux had after an upgrade and that is described in #23 . It seems to be caused by commit https://github.com/YunoHost-Apps/libreto_ynh/commit/b9b368774eaf47608127a39fd71935be54d30991 . But that commit might have been legit at that time. Maybe there is a difference in behavior between subpath and subdir install. From the recent commit history subdir install seems to be broken now, see commit https://github.com/YunoHost-Apps/libreto_ynh/commit/6f31241bfe94896331a72720f3f8e4aa84b5876a . That may be related to the issue.
 - custom pad provider config is not correctly substituted in the libreto config template ( the `// CUSTOM_PROVIDER` comments are not removed). This regression was introduced by commit https://github.com/YunoHost-Apps/libreto_ynh/commit/52c650d52ca0d2a72b75cfd26b76ff02c564e1ee 

## Solution

- replaced `location __PATH__/assets/` by `location __PATH__/libreto/assets/` in conf/nginx.conf
- replaced `// CUSTOM_PROVIDER` by `__COMMENTED_PROVIDER__` in conf/config.dist.php

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
